### PR TITLE
replace Egghead Angular videos with a more in depth tutorial

### DIFF
--- a/content.js
+++ b/content.js
@@ -373,8 +373,8 @@ var CONTENT = [
           url: "http://angularjs.org/"
         },
         {
-          name: "Egghead.io",
-          url: "http://egghead.io/lessons"
+          name: "A Better Way to Learn Angular",
+          url: "http://www.thinkster.io/pick/GtaQ0oMGIl/"
         }
       ]
     },


### PR DESCRIPTION
This change replaces the Egghead videos with a more in depth tutorial which contains the Egghead videos plus much more. When learning Angular I found the Egghead videos weren't enough, but supplementing them with the Angular Docs and the O'Reilly AngularJS book (as done in the tutorial) made for the perfect combination. 
