### PR TITLE
add egghead.io back to the angular list

### DIFF
--- a/content.js
+++ b/content.js
@@ -442,6 +442,9 @@ var CONTENT = [
           name: "Home",
           url: "http://angularjs.org/"
         },
+        { 
+          name: "egghead.io - comprehensive AngularJS training videos",
+          url: "http://egghead.io/lessons"
         {
           name: "A Better Way to Learn Angular",
           url: "http://www.thinkster.io/pick/GtaQ0oMGIl/"


### PR DESCRIPTION
There was a commit that removed egghead.io from the angular list in favor of thinkster. thinkster is great, but egghead.io is the original source and includes many videos that are _not_ available via thinkster (which embeds the egghead videos)
