### PR TITLE
Adding trailing commas to fix syntax error

### DIFF
--- a/content.js
+++ b/content.js
@@ -629,7 +629,7 @@ var CONTENT = [
       	{
       	  name: "Laravel Cheatsheet",
       	  url: "http://cheats.jesse-obrien.ca/"
-      	}
+      	},
       	{
       	  name: "Laravel 4 Mastery",
       	  url: "http://net.tutsplus.com/tutorials/php/laravel-4-mastery/"

--- a/content.js
+++ b/content.js
@@ -623,15 +623,15 @@ var CONTENT = [
       	  url: "http://laravel.com/docs"
       	},
       	{
-      	  name: "Laravel Ins and Outs"
+      	  name: "Laravel Ins and Outs",
       	  url: "http://laravel.io"
       	},
       	{
-      	  name: "Laravel Cheatsheet"
+      	  name: "Laravel Cheatsheet",
       	  url: "http://cheats.jesse-obrien.ca/"
       	}
       	{
-      	  name: "Laravel 4 Mastery"
+      	  name: "Laravel 4 Mastery",
       	  url: "http://net.tutsplus.com/tutorials/php/laravel-4-mastery/"
       	},
       	{


### PR DESCRIPTION
I get:

```
Uncaught SyntaxError: Unexpected identifier 
```

In chrome 29. I think the commas should fix it.
