### PR TITLE
Add Sublime Text Tips website link

### DIFF
--- a/content.json
+++ b/content.json
@@ -120,14 +120,14 @@
     "home": "http://www.sublimetext.com/",
     "links": [
       {
-        "name": "Sublime Text Tips",
-        "level": 0,
-        "url": "http://sublimetexttips.com/"
-      },
-      {
         "name": "tuts+",
         "level": 0,
         "url": "https://tutsplus.com/lesson/hello-2/"
+      },
+      {
+        "name": "Sublime Text Tips",
+        "level": 0,
+        "url": "http://sublimetexttips.com/"
       }
     ]
   },

--- a/content.json
+++ b/content.json
@@ -120,6 +120,11 @@
     "home": "http://www.sublimetext.com/",
     "links": [
       {
+        "name": "Sublime Text Tips",
+        "level": 0,
+        "url": "http://sublimetexttips.com/"
+      },
+      {
         "name": "tuts+",
         "level": 0,
         "url": "https://tutsplus.com/lesson/hello-2/"


### PR DESCRIPTION
Hey Jon,

Its been a while since doing a pull request, lol.  Figured I should put one in.

Anyhow, the sublime text link was looking oddly enough pretty enough lonely.  Considering how popular it is (seems like the #1 text editor in terms of popularity), I would expect more than one tuts+ link. Hence, the pull request for http://sublimetexttips.com/ .

It's a decent sublime text website--some decent stuff from 2012, and a newer 2013 posting--the guy has compiled some stuff in an ebook and advertises it, but there are some good original blog post on Sublime text usage esp from the 2012 postings.  

Honestly though, I think the twitter feed (https://twitter.com/SublimeTxtTips) for them is better than the website (the twitter feed is much more active than the website/blog resource).  Its through twitter that I found out about their website (I posted a tweet about CoronaLabs/Lua and a new Sublime Text plugin, @SublimeTxtTips retweeted it, and I noticed the URL to their website on the twitter feed).  However, Bento seems more like a learning resource not a here's a neat/good twitter feed.

Tell me what you think.

Jonathan Lai
@jonlai

P.s. Anyone else there out in the Bento community got a good Sublime Learning site?  With regards to resource, it would be good to have something like the Sublime Package Manager (forgot the link), but yah, thats not really a training/learning resource, just a nice to have.  
