### PR TITLE
Update link to RESTful Web Services lecture

### DIFF
--- a/content.json
+++ b/content.json
@@ -449,7 +449,7 @@
       {
         "name": "Designing HTTP Interfaces and RESTful Web Services",
         "level": 1,
-        "url": "http://munich2012.drupal.org/program/sessions/designing-http-interfaces-and-restful-web-services.html"
+        "url": "http://www.youtube.com/watch?v=zEyg0TnieLg"
       },
       {
         "name": "White House Web API Standards",


### PR DESCRIPTION
The video on "Designing HTTP Interfaces and RESTful Web Services" was recently removed from the DrupalCon 2012 website, resulting in a link on Bento that doesn't lead to any learning resource. I found the same video hosted on the Drupal Associaton's YouTube channel and replaced the old link with this one.

This really is the clearest lecture I've heard on REST, ever, so let's make sure other people can keep watching it too!
