### PR TITLE
Add z-index to the toolbar

### DIFF
--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -228,6 +228,7 @@ header h1 {
     width: 100%;
     text-align: center;
     margin: 0px;
+    z-index: 1;
 }
 #donate {
     display: none;


### PR DESCRIPTION
To make sure that the Facebook widget doesn't render above it.

The problem is shown here:

![screen shot 2014-03-16 at 7 06 01 pm](https://f.cloud.github.com/assets/2433509/2432332/31472696-ad60-11e3-83cc-f45b42a249a0.png)

and shown fixed here:

![screen shot 2014-03-16 at 7 11 06 pm](https://f.cloud.github.com/assets/2433509/2432335/4b049b0e-ad60-11e3-95f8-161c3faed0ef.png)
