### PR TITLE
Updated URL for Rails Tutorial

### DIFF
--- a/content.json
+++ b/content.json
@@ -1295,7 +1295,7 @@
       {
         "name": "Michael Hartl's Tutorial",
         "level": 0,
-        "url": "http://ruby.railstutorial.org/ruby-on-rails-tutorial-book"
+        "url": "https://www.railstutorial.org/book"
       },
       {
         "name": "Learn Ruby on Rails as You Modify a Craigslist Clone",


### PR DESCRIPTION
Michael Hartl's Tutorial appears to have moved. The current page 404s.
